### PR TITLE
Allow InstagramEmbedCodeConstraint to work on strings

### DIFF
--- a/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraint.php
+++ b/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraint.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraint;
  * @constraint(
  *   id = "InstagramEmbedCode",
  *   label = @Translation("Instagram embed code", context = "Validation"),
- *   type = { "entity", "entity_reference" }
+ *   type = { "entity", "entity_reference", "string", "string_long" }
  * )
  */
 class InstagramEmbedCodeConstraint extends Constraint {

--- a/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraint.php
+++ b/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraint.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraint;
  * @constraint(
  *   id = "InstagramEmbedCode",
  *   label = @Translation("Instagram embed code", context = "Validation"),
- *   type = { "entity", "entity_reference", "string", "string_long" }
+ *   type = { "string", "string_long" }
  * )
  */
 class InstagramEmbedCodeConstraint extends Constraint {

--- a/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraint.php
+++ b/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraint.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraint;
  * @constraint(
  *   id = "InstagramEmbedCode",
  *   label = @Translation("Instagram embed code", context = "Validation"),
- *   type = { "string", "string_long" }
+ *   type = { "link", "string", "string_long" }
  * )
  */
 class InstagramEmbedCodeConstraint extends Constraint {

--- a/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraintValidator.php
@@ -7,7 +7,7 @@
 
 namespace Drupal\media_entity_instagram\Plugin\Validation\Constraint;
 
-use Drupal\Core\Field\FieldItemInterface;
+use Drupal\media_entity\EmbedCodeValueTrait;
 use Drupal\media_entity_instagram\Plugin\MediaEntity\Type\Instagram;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -17,11 +17,13 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class InstagramEmbedCodeConstraintValidator extends ConstraintValidator {
 
+  use EmbedCodeValueTrait;
+
   /**
    * {@inheritdoc}
    */
   public function validate($value, Constraint $constraint) {
-    $value = $this->getValue($value);
+    $value = $this->getEmbedCode($value);
     if (!isset($value)) {
       return;
     }
@@ -35,28 +37,6 @@ class InstagramEmbedCodeConstraintValidator extends ConstraintValidator {
 
     if (empty($matches)) {
       $this->context->addViolation($constraint->message);
-    }
-  }
-
-  /**
-   * Extracts the raw value from the validator input.
-   *
-   * @param mixed $value
-   *   The input value. Can be a normal string, or a value wrapped by the
-   *   Typed Data API.
-   *
-   * @return string|null
-   */
-  protected function getValue($value) {
-    if (is_string($value)) {
-      return $value;
-    }
-    elseif ($value instanceof FieldItemInterface) {
-      $class = $value->getFieldDefinition()->getClass();
-      $property = $class::mainPropertyName();
-      if ($property) {
-        return $value->get($property);
-      }
     }
   }
 

--- a/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraintValidator.php
@@ -26,7 +26,7 @@ class InstagramEmbedCodeConstraintValidator extends ConstraintValidator {
 
     $matches = [];
     foreach (Instagram::$validationRegexp as $pattern => $key) {
-      if (preg_match($pattern, $value->value, $item_matches)) {
+      if (preg_match($pattern, $value, $item_matches)) {
         $matches[] = $item_matches;
       }
     }

--- a/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraintValidator.php
@@ -7,6 +7,7 @@
 
 namespace Drupal\media_entity_instagram\Plugin\Validation\Constraint;
 
+use Drupal\Core\Field\FieldItemInterface;
 use Drupal\media_entity_instagram\Plugin\MediaEntity\Type\Instagram;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -20,6 +21,7 @@ class InstagramEmbedCodeConstraintValidator extends ConstraintValidator {
    * {@inheritdoc}
    */
   public function validate($value, Constraint $constraint) {
+    $value = $this->getValue($value);
     if (!isset($value)) {
       return;
     }
@@ -33,6 +35,32 @@ class InstagramEmbedCodeConstraintValidator extends ConstraintValidator {
 
     if (empty($matches)) {
       $this->context->addViolation($constraint->message);
+    }
+  }
+
+  /**
+   * Extracts the raw value from the validator input.
+   *
+   * @param mixed $value
+   *   The input value. Can be a normal string, or a value wrapped by the
+   *   Typed Data API.
+   *
+   * @return string|null
+   */
+  protected function getValue($value) {
+    if (is_string($value)) {
+      return $value;
+    }
+    elseif ($value instanceof FieldItemInterface) {
+      switch ($value->getFieldDefinition()->getType()) {
+        case 'link':
+          return $value->uri;
+        case 'string':
+        case 'string_long':
+          return $value->value;
+        default:
+          break;
+      }
     }
   }
 

--- a/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraintValidator.php
@@ -19,14 +19,14 @@ class InstagramEmbedCodeConstraintValidator extends ConstraintValidator {
   /**
    * {@inheritdoc}
    */
-  public function validate($entity, Constraint $constraint) {
-    if (!isset($entity)) {
+  public function validate($value, Constraint $constraint) {
+    if (!isset($value)) {
       return;
     }
 
     $matches = [];
     foreach (Instagram::$validationRegexp as $pattern => $key) {
-      if (preg_match($pattern, $entity->value, $item_matches)) {
+      if (preg_match($pattern, $value->value, $item_matches)) {
         $matches[] = $item_matches;
       }
     }

--- a/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraintValidator.php
+++ b/src/Plugin/Validation/Constraint/InstagramEmbedCodeConstraintValidator.php
@@ -52,14 +52,10 @@ class InstagramEmbedCodeConstraintValidator extends ConstraintValidator {
       return $value;
     }
     elseif ($value instanceof FieldItemInterface) {
-      switch ($value->getFieldDefinition()->getType()) {
-        case 'link':
-          return $value->uri;
-        case 'string':
-        case 'string_long':
-          return $value->value;
-        default:
-          break;
+      $class = $value->getFieldDefinition()->getClass();
+      $property = $class::mainPropertyName();
+      if ($property) {
+        return $value->get($property);
       }
     }
   }

--- a/tests/src/Unit/ConstraintsTest.php
+++ b/tests/src/Unit/ConstraintsTest.php
@@ -7,6 +7,8 @@
 
 namespace Drupal\Tests\media_entity_instagram\Unit;
 
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemInterface;
 use Drupal\media_entity_instagram\Plugin\Validation\Constraint\InstagramEmbedCodeConstraint;
 use Drupal\media_entity_instagram\Plugin\Validation\Constraint\InstagramEmbedCodeConstraintValidator;
 use Drupal\Tests\UnitTestCase;
@@ -47,8 +49,16 @@ class ConstraintsTest extends UnitTestCase {
     $validator = new InstagramEmbedCodeConstraintValidator();
     $validator->initialize($execution_context);
 
-    $data = new \stdClass();
-    $data->value = $embed_code;
+    // $data is a mock field item (string or string_long type, depending on the
+    // length of the embed code) which contains the embed code.
+    $data = $this->getMock(FieldItemInterface::class);
+
+    $field_definition = $this->getMock(FieldDefinitionInterface::class);
+    $field_definition->method('getType')->willReturn(strlen($embed_code) > 255 ? 'string_long' : 'string');
+
+    $data->method('getFieldDefinition')->willReturn($field_definition);
+    $data->method('__get')->with('value')->willReturn($embed_code);
+
     $validator->validate($data, $constraint);
   }
 

--- a/tests/src/Unit/ConstraintsTest.php
+++ b/tests/src/Unit/ConstraintsTest.php
@@ -9,6 +9,7 @@ namespace Drupal\Tests\media_entity_instagram\Unit;
 
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemInterface;
+use Drupal\Core\Field\Plugin\Field\FieldType\StringLongItem;
 use Drupal\media_entity_instagram\Plugin\Validation\Constraint\InstagramEmbedCodeConstraint;
 use Drupal\media_entity_instagram\Plugin\Validation\Constraint\InstagramEmbedCodeConstraintValidator;
 use Drupal\Tests\UnitTestCase;
@@ -49,17 +50,17 @@ class ConstraintsTest extends UnitTestCase {
     $validator = new InstagramEmbedCodeConstraintValidator();
     $validator->initialize($execution_context);
 
-    // $data is a mock field item (string or string_long type, depending on the
-    // length of the embed code) which contains the embed code.
-    $data = $this->getMock(FieldItemInterface::class);
+    // We need to mock the string_long field definition so that the validator
+    // will call StringLongItem::mainPropertyName() in getValue().
+    $definition = $this->prophesize(FieldDefinitionInterface::class);
+    $definition->getClass()->willReturn(StringLongItem::class);
 
-    $field_definition = $this->getMock(FieldDefinitionInterface::class);
-    $field_definition->method('getType')->willReturn(strlen($embed_code) > 255 ? 'string_long' : 'string');
+    // $data is a mock string_long field item which contains the embed code.
+    $data = $this->prophesize(FieldItemInterface::class);
+    $data->getFieldDefinition()->willReturn($definition->reveal());
+    $data->get('value')->willReturn($embed_code);
 
-    $data->method('getFieldDefinition')->willReturn($field_definition);
-    $data->method('__get')->with('value')->willReturn($embed_code);
-
-    $validator->validate($data, $constraint);
+    $validator->validate($data->reveal(), $constraint);
   }
 
   /**


### PR DESCRIPTION
As in drupal-media/media_entity_twitter#17, it'd be handy if strings could be validated as Instagram embed codes.
