### PR TITLE
Fixed invalid class constant fatal

### DIFF
--- a/src/Plugin/MediaEntity/Type/Instagram.php
+++ b/src/Plugin/MediaEntity/Type/Instagram.php
@@ -262,7 +262,7 @@ class Instagram extends MediaTypeBase {
       $source_field = $this->configuration['source_field'];
       if ($media->hasField($source_field)) {
         $property_name = $media->{$source_field}->first()->mainPropertyName();
-        foreach (self::validationRegexp as $pattern => $key) {
+        foreach (self::$validationRegexp as $pattern => $key) {
           if (preg_match($pattern, $media->{$source_field}->{$property_name}, $matches)) {
             return $matches;
           }

--- a/src/Plugin/MediaEntity/Type/Instagram.php
+++ b/src/Plugin/MediaEntity/Type/Instagram.php
@@ -262,7 +262,7 @@ class Instagram extends MediaTypeBase {
       $source_field = $this->configuration['source_field'];
       if ($media->hasField($source_field)) {
         $property_name = $media->{$source_field}->first()->mainPropertyName();
-        foreach (self::$validationRegexp as $pattern => $key) {
+        foreach (static::$validationRegexp as $pattern => $key) {
           if (preg_match($pattern, $media->{$source_field}->{$property_name}, $matches)) {
             return $matches;
           }


### PR DESCRIPTION
In the Instagram media type class, self::validation_regexp is not a constant. This produces a fatal error in certain circumstances. (Install media_entity_instagram and try to create an instagram entity, you're gonna have a bad time!)

Here's the quick fix.
