### PR TITLE
Fix failing tests

### DIFF
--- a/src/Plugin/MediaEntity/Type/Instagram.php
+++ b/src/Plugin/MediaEntity/Type/Instagram.php
@@ -262,7 +262,7 @@ class Instagram extends MediaTypeBase {
       $source_field = $this->configuration['source_field'];
       if ($media->hasField($source_field)) {
         $property_name = $media->{$source_field}->first()->mainPropertyName();
-        foreach (self::validationRegexp as $pattern => $key) {
+        foreach (self::$validationRegexp as $pattern => $key) {
           if (preg_match($pattern, $media->{$source_field}->{$property_name}, $matches)) {
             return $matches;
           }

--- a/src/Plugin/MediaEntity/Type/Instagram.php
+++ b/src/Plugin/MediaEntity/Type/Instagram.php
@@ -262,7 +262,7 @@ class Instagram extends MediaTypeBase {
       $source_field = $this->configuration['source_field'];
       if ($media->hasField($source_field)) {
         $property_name = $media->{$source_field}->first()->mainPropertyName();
-        foreach (self::$validationRegexp as $pattern => $key) {
+        foreach (static::$validationRegexp as $pattern => $key) {
           if (preg_match($pattern, $media->{$source_field}->{$property_name}, $matches)) {
             return $matches;
           }

--- a/tests/src/Unit/ConstraintsTest.php
+++ b/tests/src/Unit/ConstraintsTest.php
@@ -7,9 +7,8 @@
 
 namespace Drupal\Tests\media_entity_instagram\Unit;
 
-use Drupal\Core\Field\FieldDefinitionInterface;
-use Drupal\Core\Field\FieldItemInterface;
 use Drupal\Core\Field\Plugin\Field\FieldType\StringLongItem;
+use Drupal\Core\TypedData\ComplexDataDefinitionInterface;
 use Drupal\media_entity_instagram\Plugin\Validation\Constraint\InstagramEmbedCodeConstraint;
 use Drupal\media_entity_instagram\Plugin\Validation\Constraint\InstagramEmbedCodeConstraintValidator;
 use Drupal\Tests\UnitTestCase;
@@ -50,17 +49,12 @@ class ConstraintsTest extends UnitTestCase {
     $validator = new InstagramEmbedCodeConstraintValidator();
     $validator->initialize($execution_context);
 
-    // We need to mock the string_long field definition so that the validator
-    // will call StringLongItem::mainPropertyName() in getValue().
-    $definition = $this->prophesize(FieldDefinitionInterface::class);
-    $definition->getClass()->willReturn(StringLongItem::class);
+    $definition = $this->getMock(ComplexDataDefinitionInterface::class);
+    $definition->method('getPropertyDefinitions')->willReturn([]);
 
-    // $data is a mock string_long field item which contains the embed code.
-    $data = $this->prophesize(FieldItemInterface::class);
-    $data->getFieldDefinition()->willReturn($definition->reveal());
-    $data->get('value')->willReturn($embed_code);
-
-    $validator->validate($data->reveal(), $constraint);
+    $data = new StringLongItem($definition);
+    $data->set('value', $embed_code);
+    $validator->validate($data, $constraint);
   }
 
   /**


### PR DESCRIPTION
Due to changes in Media Entity (namely, EmbedCodeValueTrait::getEmbedCode()), the constraint validation test in Media Entity Instagram has broken. This fixes it.
